### PR TITLE
release/0.0.7.dev3

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -54,6 +54,7 @@ jobs:
       - name: Run the django tests
         run: poetry run dj/manage.py test
 
+  #  Is this working properly?
   versioning:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -25,6 +25,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.11'
+          cache: 'pip' # caching pip dependencies
       - uses: pre-commit/action@v3.0.0
 
   testing:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Get version and release type from pyproject.toml
         run: |
           echo "VERSION=$(grep '^version =' pyproject.toml | awk -F\" '{print $2}')" >> $GITHUB_ENV
-          RELEASE_TYPE=$(echo $VERSION | grep -oP '(?<=-)[a-z]+' | awk 'NR==1')
+          RELEASE_TYPE=$(echo $VERSION | grep -oP '(\.|-)[a-z]+' | awk 'NR==1' | sed 's/\.//')
           if [[ -z "$RELEASE_TYPE" ]]; then
             RELEASE_TYPE="final"
           fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-template"
-version = "0.0.7.dev2"
+version = "0.0.7.dev3"
 description = "A streamlined Django template designed for practical, real-world applications, with essential configurations and best practices integrated out of the box."
 authors = ["Azat <8280770+azataiot@users.noreply.github.com>"]
 license = "MIT"


### PR DESCRIPTION
- Bump actions/checkout from 3 to 4
- Bumped version number to 0.0.7.dev2
- we want to only publish release for either PEP440 final or post release.
- Bumped version number to 0.0.7.dev3
- release type not parsed properly
